### PR TITLE
Add dot notation support

### DIFF
--- a/src/DefinedParameters.php
+++ b/src/DefinedParameters.php
@@ -14,11 +14,12 @@ class DefinedParameters extends Parameters
      *
      * @param   Definitions $definitions
      * @param   array       $parameters
+     * @param   string      $sep
      */
-    public function __construct(Definitions $definitions, array $parameters = [])
+    public function __construct(Definitions $definitions, array $parameters = [], $sep = '.')
     {
         $this->definitions = $definitions;
-        parent::__construct($parameters);
+        parent::__construct($parameters, $sep);
     }
 
     /**
@@ -68,13 +69,17 @@ class DefinedParameters extends Parameters
     /**
      * {@inheritdoc}
      */
-    public function set($key, $value)
+    public function set($path, $value)
     {
-        if (false === $this->definitions->has($key)) {
+        $keys = $this->explode($path);
+        if (count($keys) > 1) {
+            throw new \BadMethodCallException('Setting values via a path for a defined parameter instance is not yet implemented.');
+        }
+        if (false === $this->definitions->has($keys[0])) {
             return $this;
         }
-        $value = $this->definitions->convertFor($key, $value);
-        return parent::set($key, $value);
+        $value = $this->definitions->convertFor($keys[0], $value);
+        return parent::set($keys[0], $value);
     }
 
     /**

--- a/src/Definitions.php
+++ b/src/Definitions.php
@@ -72,7 +72,7 @@ class Definitions
                 }
                 return (String) $value;
             case 'object':
-                return (Object) $value;
+                return (Array) $value;
             case 'string':
                 return (String) $value;
             case 'integer':


### PR DESCRIPTION
Parameters with dimension can now be accessed and set via dot notation.

Examples:
If the parameters array is as follows:

```
[
    'foo' => 'bar',
    'baz' => [
        'key' => 'value'
    ],
]
```

The following will return...
- `$params->get('foo')` = `'bar'`
- `$params->get('foo.bar')` = `null`
- `$params->get('baz')` = `['key' => 'value']`
- `$params->get('baz.key')` = `'value'`
- `$params->get('baz.test')` = `null`
- `$params->get('baz.key.value')` = `null`

The path separator value (by default a `'.'`) can be changed when the `Parameters` instance is created/constructed. For example, using a sep value of `|` would change the get calls such as `$params->get('baz|key')`
